### PR TITLE
wip: implement unsignedInteger parsing type

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 <!-- cargo-rdme start -->
 
 This crate aims at providing safe representations
-of [XSD built-in data types][xsd].
+of [XSD built-in data types][xsd], including decimal types (integer, decimal), string types, 
+datetime types, and binary types.
 
 [xsd]: <https://www.w3.org/TR/xmlschema-2/#built-in-datatypes>
 
@@ -36,6 +37,19 @@ let lexical_repr = xsd_types::lexical::Decimal::new(string).unwrap();
 // Interprets the lexical representation (value domain).
 use xsd_types::lexical::LexicalFormOf;
 let value_repr: xsd_types::Decimal = lexical_repr.try_as_value().unwrap();
+```
+
+You can also work with other XSD types like `UnsignedInteger`:
+
+```rust
+// Parse an unsigned integer
+let uint = xsd_types::lexical::UnsignedInteger::new("42").unwrap();
+assert!(uint.is_positive()); // Test if positive
+assert!(!uint.is_zero());    // Test if zero
+
+// Convert to a Rust primitive type
+let value: u32 = u32::try_from(uint).unwrap();
+assert_eq!(value, 42);
 ```
 
 Of course it is possible to parse the value directly into the value domain

--- a/src/lexical/decimal/integer.rs
+++ b/src/lexical/decimal/integer.rs
@@ -9,9 +9,11 @@ use std::str::FromStr;
 
 mod non_negative_integer;
 mod non_positive_integer;
+mod unsigned_integer;
 
 pub use non_negative_integer::*;
 pub use non_positive_integer::*;
+pub use unsigned_integer::*;
 
 lexical_form! {
 	/// Integer number.

--- a/src/lexical/decimal/integer/unsigned_integer.rs
+++ b/src/lexical/decimal/integer/unsigned_integer.rs
@@ -1,0 +1,323 @@
+use crate::lexical::lexical_form;
+
+use super::{
+	Decimal, DecimalBuf, Integer, IntegerBuf, NonNegativeInteger, NonNegativeIntegerBuf, Overflow,
+	Sign,
+};
+use std::borrow::{Borrow, ToOwned};
+use std::cmp::Ordering;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+
+lexical_form! {
+	/// Unsigned integer number.
+	///
+	/// See: <http://www.w3.org/2001/XMLSchema#unsignedInt>
+	ty: UnsignedInteger,
+
+	/// Owned unsigned integer number.
+	///
+	/// See: <http://www.w3.org/2001/XMLSchema#unsignedInt>
+	buffer: UnsignedIntegerBuf,
+
+	/// Creates a new unsigned integer from a string.
+	///
+	/// The input string must be a [valid XSD unsignedInt](http://www.w3.org/2001/XMLSchema#unsignedInt).
+	/// an [`InvalidUnsignedInteger`] error is returned.
+	new,
+
+	/// Creates a new unsigned integer from a string without checking it.
+	///
+	/// # Safety
+	///
+	/// The input string must be a [valid XSD unsignedInt](http://www.w3.org/2001/XMLSchema#unsignedInt).
+	new_unchecked,
+
+	value: crate::UnsignedInteger,
+	error: InvalidUnsignedInteger,
+	as_ref: as_unsigned_integer,
+	parent_forms: {
+		as_non_negative_integer: NonNegativeInteger, NonNegativeIntegerBuf,
+		as_integer: Integer, IntegerBuf,
+		as_decimal: Decimal, DecimalBuf
+	}
+}
+
+impl UnsignedInteger {
+	/// Returns `true` if `self` is positive
+	/// and `false` if the number is zero.
+	pub fn is_positive(&self) -> bool {
+		for c in &self.0 {
+			match c {
+				b'+' | b'0' => (),
+				_ => return true,
+			}
+		}
+
+		false
+	}
+
+	/// Returns `true` if `self` is zero
+	/// and `false` otherwise.
+	pub fn is_zero(&self) -> bool {
+		for c in &self.0 {
+			if !matches!(c, b'+' | b'0') {
+				return false;
+			}
+		}
+
+		true
+	}
+
+	pub fn sign(&self) -> Sign {
+		for c in &self.0 {
+			match c {
+				b'+' | b'0' => (),
+				_ => return Sign::Positive,
+			}
+		}
+
+		Sign::Zero
+	}
+
+	/// Returns the canonical form of `self` (without leading zeros).
+	pub fn canonical(&self) -> &Self {
+		let mut last_zero = 0;
+		for (i, c) in self.0.iter().enumerate() {
+			match c {
+				b'+' => (),
+				b'0' => last_zero = i,
+				_ => return unsafe { Self::new_unchecked(&self.0[i..]) },
+			}
+		}
+
+		unsafe { Self::new_unchecked(&self.0[last_zero..]) }
+	}
+
+	#[inline(always)]
+	fn as_canonical_str(&self) -> &str {
+		self.canonical().as_str()
+	}
+
+	#[inline(always)]
+	pub fn value(&self) -> crate::UnsignedInteger {
+		use num_bigint::BigUint;
+		use num_traits::Num;
+		crate::UnsignedInteger::new(BigUint::from_str_radix(self.as_str(), 10).unwrap())
+	}
+}
+
+impl PartialEq for UnsignedInteger {
+	fn eq(&self, other: &Self) -> bool {
+		self.as_canonical_str() == other.as_canonical_str()
+	}
+}
+
+impl Eq for UnsignedInteger {}
+
+impl Hash for UnsignedInteger {
+	fn hash<H: Hasher>(&self, h: &mut H) {
+		self.as_canonical_str().hash(h)
+	}
+}
+
+impl Ord for UnsignedInteger {
+	fn cmp(&self, other: &Self) -> Ordering {
+		let a = &self.canonical().0;
+		let b = &other.canonical().0;
+
+		match a.len().cmp(&b.len()) {
+			Ordering::Equal => a.cmp(b),
+			other => other,
+		}
+	}
+}
+
+impl PartialOrd for UnsignedInteger {
+	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+		Some(self.cmp(other))
+	}
+}
+
+impl UnsignedIntegerBuf {
+	pub fn zero() -> Self {
+		unsafe { Self::new_unchecked("0".to_string()) }
+	}
+
+	pub fn one() -> Self {
+		unsafe { Self::new_unchecked("1".to_string()) }
+	}
+}
+
+impl Default for UnsignedIntegerBuf {
+	fn default() -> Self {
+		Self::zero()
+	}
+}
+
+impl PartialOrd for UnsignedIntegerBuf {
+	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+		Some(self.cmp(other))
+	}
+}
+
+impl Ord for UnsignedIntegerBuf {
+	fn cmp(&self, other: &Self) -> Ordering {
+		self.as_integer().cmp(other.as_integer())
+	}
+}
+
+macro_rules! number_conversion {
+	{ $($ty:ty),* } => {
+		$(
+			impl From<$ty> for UnsignedIntegerBuf {
+				fn from(i: $ty) -> Self {
+					unsafe { UnsignedIntegerBuf::new_unchecked(i.to_string()) }
+				}
+			}
+
+			impl<'a> TryFrom<&'a UnsignedInteger> for $ty {
+				type Error = Overflow;
+
+				fn try_from(i: &'a UnsignedInteger) -> Result<Self, Overflow> {
+					i.as_str().parse().map_err(|_| Overflow)
+				}
+			}
+
+			impl TryFrom<UnsignedIntegerBuf> for $ty {
+				type Error = Overflow;
+
+				fn try_from(i: UnsignedIntegerBuf) -> Result<Self, Overflow> {
+					i.as_str().parse().map_err(|_| Overflow)
+				}
+			}
+		)*
+	};
+}
+
+number_conversion! {
+	u8,
+	i8,
+	u16,
+	i16,
+	u32,
+	i32,
+	u64,
+	i64,
+	u128,
+	i128,
+	usize,
+	isize
+}
+
+fn check_bytes(s: &[u8]) -> bool {
+	check(s.iter().copied())
+}
+
+fn check<C: Iterator<Item = u8>>(mut chars: C) -> bool {
+	enum State {
+		Initial,
+		NonEmptyInteger,
+		Integer,
+		Zero,
+	}
+
+	let mut state = State::Initial;
+
+	loop {
+		state = match state {
+			State::Initial => match chars.next() {
+				Some(b'+') => State::NonEmptyInteger,
+				Some(b'-') => State::Zero,
+				Some(b'0'..=b'9') => State::Integer,
+				_ => break false,
+			},
+			State::NonEmptyInteger => match chars.next() {
+				Some(b'0'..=b'9') => State::Integer,
+				_ => break false,
+			},
+			State::Integer => match chars.next() {
+				Some(b'0'..=b'9') => State::Integer,
+				Some(_) => break false,
+				None => break true,
+			},
+			State::Zero => match chars.next() {
+				Some(b'0') => State::Zero,
+				_ => break false,
+			},
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn parse_01() {
+		UnsignedInteger::new("0").unwrap();
+	}
+
+	#[test]
+	fn parse_02() {
+		UnsignedInteger::new("+42").unwrap();
+	}
+
+	#[test]
+	#[should_panic]
+	fn parse_03() {
+		UnsignedInteger::new("-42").unwrap();
+	}
+
+	#[test]
+	fn canonical_01() {
+		assert_eq!(
+			UnsignedInteger::new("01").unwrap().canonical().as_str(),
+			"1"
+		)
+	}
+
+	#[test]
+	fn canonical_02() {
+		assert_eq!(
+			UnsignedInteger::new("00").unwrap().canonical().as_str(),
+			"0"
+		)
+	}
+
+	#[test]
+	fn canonical_03() {
+		assert_eq!(
+			UnsignedInteger::new("+00000").unwrap().canonical().as_str(),
+			"0"
+		)
+	}
+
+	#[test]
+	fn eq_01() {
+		assert_eq!(
+			UnsignedInteger::new("+001").unwrap(),
+			UnsignedInteger::new("1").unwrap()
+		)
+	}
+
+	#[test]
+	fn cmp_01() {
+		assert!(UnsignedInteger::new("123").unwrap() < UnsignedInteger::new("456").unwrap())
+	}
+
+	#[test]
+	fn cmp_02() {
+		assert!(UnsignedInteger::new("1230").unwrap() > UnsignedInteger::new("456").unwrap())
+	}
+
+	#[test]
+	fn cmp_03() {
+		assert_eq!(
+			UnsignedInteger::new("+123456")
+				.unwrap()
+				.cmp(UnsignedInteger::new("0000123456").unwrap()),
+			Ordering::Equal
+		)
+	}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,6 +201,9 @@ pub const XSD_NON_POSITIVE_INTEGER: &Iri =
 /// <http://www.w3.org/2001/XMLSchema#negativeInteger> datatype IRI.
 pub const XSD_NEGATIVE_INTEGER: &Iri = iri!("http://www.w3.org/2001/XMLSchema#negativeInteger");
 
+/// <http://www.w3.org/2001/XMLSchema#unsignedInteger> datatype IRI.
+pub const XSD_UNSIGNED_INTEGER: &Iri = iri!("http://www.w3.org/2001/XMLSchema#unsignedInteger");
+
 /// <http://www.w3.org/2001/XMLSchema#long> datatype IRI.
 pub const XSD_LONG: &Iri = iri!("http://www.w3.org/2001/XMLSchema#long");
 

--- a/src/value/decimal/integer.rs
+++ b/src/value/decimal/integer.rs
@@ -19,9 +19,11 @@ use super::{Sign, I16_MIN, I32_MIN, I64_MIN, I8_MIN, U16_MAX, U32_MAX, U64_MAX, 
 
 mod non_negative_integer;
 mod non_positive_integer;
+mod unsigned_integer;
 
 pub use non_negative_integer::*;
 pub use non_positive_integer::*;
+pub use unsigned_integer::*;
 
 /// Integer number.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]

--- a/src/value/decimal/integer/unsigned_integer.rs
+++ b/src/value/decimal/integer/unsigned_integer.rs
@@ -1,0 +1,300 @@
+use std::{
+	borrow::Borrow,
+	fmt,
+	ops::{Add, Div, Mul, Sub},
+	str::FromStr,
+};
+
+use num_bigint::{BigInt, BigUint};
+use num_traits::Zero;
+
+use crate::{
+	lexical::{self, LexicalFormOf},
+	Datatype, NonNegativeInteger, NonNegativeIntegerDatatype, ParseXsd, UnsignedIntDatatype,
+	UnsignedLongDatatype, UnsignedShortDatatype, XsdValue,
+};
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct UnsignedInteger(BigUint);
+
+impl UnsignedInteger {
+	/// Create a new unsigned integer from a `BigUint`.
+	pub fn new(n: BigUint) -> Self {
+		Self(n)
+	}
+
+	/// Create a new unsigned integer from a `BigUint`.
+	///
+	/// # Safety
+	///
+	/// The input number must be non-negative (which is always true for BigUint).
+	pub unsafe fn new_unchecked(n: BigUint) -> Self {
+		Self(n)
+	}
+
+	/// Creates an unsigned integer from its big endian bytes representation.
+	pub fn from_bytes_be(bytes: &[u8]) -> Self {
+		Self(BigUint::from_bytes_be(bytes))
+	}
+
+	/// Creates an unsigned integer from its little endian bytes representation.
+	pub fn from_bytes_le(bytes: &[u8]) -> Self {
+		Self(BigUint::from_bytes_le(bytes))
+	}
+
+	#[inline(always)]
+	pub fn into_big_uint(self) -> BigUint {
+		self.0
+	}
+
+	#[inline(always)]
+	pub fn zero() -> Self {
+		Self(BigUint::zero())
+	}
+
+	#[inline(always)]
+	pub fn is_zero(&self) -> bool {
+		self.0.is_zero()
+	}
+
+	pub fn unsigned_integer_type(&self) -> NonNegativeIntegerDatatype {
+		if !self.is_zero() {
+			if self.0 <= BigUint::from(u8::MAX) {
+				UnsignedShortDatatype::UnsignedByte.into()
+			} else if self.0 <= BigUint::from(u16::MAX) {
+				UnsignedShortDatatype::UnsignedShort.into()
+			} else if self.0 <= BigUint::from(u32::MAX) {
+				UnsignedIntDatatype::UnsignedInt.into()
+			} else if self.0 <= BigUint::from(u64::MAX) {
+				UnsignedLongDatatype::UnsignedLong.into()
+			} else {
+				NonNegativeIntegerDatatype::PositiveInteger
+			}
+		} else {
+			NonNegativeIntegerDatatype::NonNegativeInteger
+		}
+	}
+
+	/// Returns a lexical representation of this unsigned integer.
+	#[inline(always)]
+	pub fn lexical_representation(&self) -> lexical::UnsignedIntegerBuf {
+		unsafe {
+			// This is safe because the `Display::fmt` method matches the
+			// XSD lexical representation.
+			lexical::UnsignedIntegerBuf::new_unchecked(format!("{}", self))
+		}
+	}
+
+	pub fn to_bytes_be(&self) -> Vec<u8> {
+		self.0.to_bytes_be()
+	}
+
+	pub fn to_bytes_le(&self) -> Vec<u8> {
+		self.0.to_bytes_le()
+	}
+}
+
+impl XsdValue for UnsignedInteger {
+	fn datatype(&self) -> Datatype {
+		self.unsigned_integer_type().into()
+	}
+}
+
+impl ParseXsd for UnsignedInteger {
+	type LexicalForm = lexical::UnsignedInteger;
+}
+
+impl LexicalFormOf<UnsignedInteger> for lexical::UnsignedInteger {
+	type ValueError = std::convert::Infallible;
+
+	fn try_as_value(&self) -> Result<UnsignedInteger, Self::ValueError> {
+		Ok(self.value())
+	}
+}
+
+impl From<UnsignedInteger> for BigUint {
+	fn from(value: UnsignedInteger) -> Self {
+		value.0
+	}
+}
+
+impl<'a> From<&'a lexical::UnsignedInteger> for UnsignedInteger {
+	#[inline(always)]
+	fn from(value: &'a lexical::UnsignedInteger) -> Self {
+		use num_traits::Num;
+		Self(BigUint::from_str_radix(value.as_str(), 10).unwrap())
+	}
+}
+
+impl From<lexical::UnsignedIntegerBuf> for UnsignedInteger {
+	#[inline(always)]
+	fn from(value: lexical::UnsignedIntegerBuf) -> Self {
+		value.as_unsigned_integer().into()
+	}
+}
+
+impl FromStr for UnsignedInteger {
+	type Err = lexical::InvalidUnsignedInteger;
+
+	#[inline(always)]
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		let l = lexical::UnsignedInteger::new(s)?;
+		Ok(l.into())
+	}
+}
+
+impl fmt::Display for UnsignedInteger {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		self.0.fmt(f)
+	}
+}
+
+impl AsRef<BigUint> for UnsignedInteger {
+	#[inline(always)]
+	fn as_ref(&self) -> &BigUint {
+		&self.0
+	}
+}
+
+impl Borrow<BigUint> for UnsignedInteger {
+	#[inline(always)]
+	fn borrow(&self) -> &BigUint {
+		&self.0
+	}
+}
+
+impl From<NonNegativeInteger> for UnsignedInteger {
+	fn from(value: NonNegativeInteger) -> Self {
+		let big_int: BigInt = value.into();
+		Self(big_int.try_into().unwrap())
+	}
+}
+
+impl From<UnsignedInteger> for NonNegativeInteger {
+	fn from(value: UnsignedInteger) -> Self {
+		unsafe {
+			Self::new_unchecked(value.0.into())
+		}
+	}
+}
+
+macro_rules! from {
+	{ $( $ty:ty ),* } => {
+		$(
+			impl From<$ty> for UnsignedInteger {
+				fn from(value: $ty) -> Self {
+					Self(value.into())
+				}
+			}
+		)*
+	};
+}
+
+from!(u8, u16, u32, u64, usize);
+
+#[derive(Debug, thiserror::Error)]
+#[error("unsigned integer out of supported bounds: {0}")]
+pub struct UnsignedIntegerOutOfTargetBounds(pub UnsignedInteger);
+
+macro_rules! try_into {
+	{ $( $ty:ty ),* } => {
+		$(
+			impl TryFrom<UnsignedInteger> for $ty {
+				type Error = UnsignedIntegerOutOfTargetBounds;
+
+				fn try_from(value: UnsignedInteger) -> Result<Self, Self::Error> {
+					let biguint = value.0.clone();
+					biguint.try_into().map_err(|_| UnsignedIntegerOutOfTargetBounds(value))
+				}
+			}
+		)*
+	};
+}
+
+try_into!(u8, u16, u32, u64, usize, i8, i16, i32, i64, isize);
+
+// Implement arithmetic operations for UnsignedInteger
+impl Add for UnsignedInteger {
+	type Output = Self;
+
+	fn add(self, rhs: Self) -> Self::Output {
+		Self(self.0 + rhs.0)
+	}
+}
+
+impl Sub for UnsignedInteger {
+	type Output = Self;
+
+	fn sub(self, rhs: Self) -> Self::Output {
+		if self.0 < rhs.0 {
+			panic!("attempt to subtract with overflow")
+		}
+		Self(self.0 - rhs.0)
+	}
+}
+
+impl Mul for UnsignedInteger {
+	type Output = Self;
+
+	fn mul(self, rhs: Self) -> Self::Output {
+		Self(self.0 * rhs.0)
+	}
+}
+
+impl Div for UnsignedInteger {
+	type Output = Self;
+
+	fn div(self, rhs: Self) -> Self::Output {
+		if rhs.is_zero() {
+			panic!("attempt to divide by zero")
+		}
+		Self(self.0 / rhs.0)
+	}
+}
+
+// Implement other arithmetic operations for common integer types
+macro_rules! impl_arithmetic_with_unsigned_types {
+	{ $( $ty:ty ),* } => {
+		$(
+			impl Add<$ty> for UnsignedInteger {
+				type Output = Self;
+
+				fn add(self, rhs: $ty) -> Self::Output {
+					Self(self.0 + rhs)
+				}
+			}
+
+			impl Sub<$ty> for UnsignedInteger {
+				type Output = Self;
+
+				fn sub(self, rhs: $ty) -> Self::Output {
+					if self.0 < BigUint::from(rhs) {
+						panic!("attempt to subtract with overflow")
+					}
+					Self(self.0 - rhs)
+				}
+			}
+
+			impl Mul<$ty> for UnsignedInteger {
+				type Output = Self;
+
+				fn mul(self, rhs: $ty) -> Self::Output {
+					Self(self.0 * rhs)
+				}
+			}
+
+			impl Div<$ty> for UnsignedInteger {
+				type Output = Self;
+
+				fn div(self, rhs: $ty) -> Self::Output {
+					if rhs == 0 {
+						panic!("attempt to divide by zero")
+					}
+					Self(self.0 / rhs)
+				}
+			}
+		)*
+	};
+}
+
+impl_arithmetic_with_unsigned_types!(u8, u16, u32, u64, usize);

--- a/tests/unsigned_integer.rs
+++ b/tests/unsigned_integer.rs
@@ -1,0 +1,126 @@
+use std::str::FromStr;
+use xsd_types::lexical::{UnsignedInteger, UnsignedIntegerBuf};
+
+#[test]
+fn test_valid_values() {
+    // Test some valid unsigned integer values
+    assert!(UnsignedInteger::new("0").is_ok());
+    assert!(UnsignedInteger::new("1").is_ok());
+    assert!(UnsignedInteger::new("42").is_ok());
+    assert!(UnsignedInteger::new("123456789").is_ok());
+    assert!(UnsignedInteger::new("+42").is_ok());
+    assert!(UnsignedInteger::new("+0").is_ok());
+}
+
+#[test]
+fn test_invalid_values() {
+    // Test some invalid unsigned integer values
+    assert!(UnsignedInteger::new("-1").is_err());
+    assert!(UnsignedInteger::new("-42").is_err());
+    assert!(UnsignedInteger::new("1.5").is_err());
+    assert!(UnsignedInteger::new("abc").is_err());
+    assert!(UnsignedInteger::new("").is_err());
+}
+
+#[test]
+fn test_canonical_form() {
+    // Test canonical form removes leading zeros
+    assert_eq!(UnsignedInteger::new("0").unwrap().canonical().as_str(), "0");
+    assert_eq!(UnsignedInteger::new("00").unwrap().canonical().as_str(), "0");
+    assert_eq!(UnsignedInteger::new("01").unwrap().canonical().as_str(), "1");
+    assert_eq!(UnsignedInteger::new("001").unwrap().canonical().as_str(), "1");
+    assert_eq!(UnsignedInteger::new("+01").unwrap().canonical().as_str(), "1");
+    assert_eq!(UnsignedInteger::new("+001").unwrap().canonical().as_str(), "1");
+}
+
+#[test]
+fn test_equality() {
+    // Test equality with different representations
+    assert_eq!(UnsignedInteger::new("42").unwrap(), UnsignedInteger::new("42").unwrap());
+    assert_eq!(UnsignedInteger::new("042").unwrap(), UnsignedInteger::new("42").unwrap());
+    assert_eq!(UnsignedInteger::new("+42").unwrap(), UnsignedInteger::new("42").unwrap());
+    assert_eq!(UnsignedInteger::new("+042").unwrap(), UnsignedInteger::new("42").unwrap());
+    
+    // Test inequality
+    assert_ne!(UnsignedInteger::new("42").unwrap(), UnsignedInteger::new("43").unwrap());
+}
+
+#[test]
+fn test_comparison() {
+    // Test ordering
+    assert!(UnsignedInteger::new("42").unwrap() < UnsignedInteger::new("100").unwrap());
+    assert!(UnsignedInteger::new("100").unwrap() > UnsignedInteger::new("42").unwrap());
+    assert!(UnsignedInteger::new("42").unwrap() <= UnsignedInteger::new("42").unwrap());
+    assert!(UnsignedInteger::new("42").unwrap() >= UnsignedInteger::new("42").unwrap());
+}
+
+#[test]
+fn test_owned_type() {
+    // Test the owned type
+    let buf = UnsignedIntegerBuf::from_str("42").unwrap();
+    assert_eq!(buf.as_str(), "42");
+    
+    // Test zero and one constructors
+    let zero = UnsignedIntegerBuf::zero();
+    assert_eq!(zero.as_str(), "0");
+    
+    let one = UnsignedIntegerBuf::one();
+    assert_eq!(one.as_str(), "1");
+}
+
+#[test]
+fn test_conversion() {
+    // Test conversion to primitive types
+    let uint = UnsignedInteger::new("42").unwrap();
+    
+    let u8_val: Result<u8, _> = u8::try_from(uint);
+    assert!(u8_val.is_ok());
+    if let Ok(val) = u8_val {
+        assert_eq!(val, 42u8);
+    }
+    
+    let u16_val: Result<u16, _> = u16::try_from(UnsignedInteger::new("42").unwrap());
+    assert!(u16_val.is_ok());
+    if let Ok(val) = u16_val {
+        assert_eq!(val, 42u16);
+    }
+    
+    let u32_val: Result<u32, _> = u32::try_from(UnsignedInteger::new("42").unwrap());
+    assert!(u32_val.is_ok());
+    if let Ok(val) = u32_val {
+        assert_eq!(val, 42u32);
+    }
+    
+    let u64_val: Result<u64, _> = u64::try_from(UnsignedInteger::new("42").unwrap());
+    assert!(u64_val.is_ok());
+    if let Ok(val) = u64_val {
+        assert_eq!(val, 42u64);
+    }
+    
+    // Test overflow
+    let large = UnsignedInteger::new("300").unwrap();
+    let u8_large: Result<u8, _> = u8::try_from(large);
+    assert!(u8_large.is_err());
+}
+
+#[test]
+fn test_is_positive_and_is_zero() {
+    // Test is_positive
+    assert!(UnsignedInteger::new("1").unwrap().is_positive());
+    assert!(UnsignedInteger::new("42").unwrap().is_positive());
+    assert!(!UnsignedInteger::new("0").unwrap().is_positive());
+    
+    // Test is_zero
+    assert!(UnsignedInteger::new("0").unwrap().is_zero());
+    assert!(UnsignedInteger::new("+0").unwrap().is_zero());
+    assert!(UnsignedInteger::new("00").unwrap().is_zero());
+    assert!(!UnsignedInteger::new("1").unwrap().is_zero());
+}
+
+#[test]
+fn test_sign() {
+    use xsd_types::lexical::Sign;
+    
+    assert_eq!(UnsignedInteger::new("42").unwrap().sign(), Sign::Positive);
+    assert_eq!(UnsignedInteger::new("0").unwrap().sign(), Sign::Zero);
+}


### PR DESCRIPTION
@timothee-haudebourg 

I didn't see `unsignedInteger` implemented as a type. I am not sure whether these changes are necessary.

Adding this type in case I can get it to unblock rdf quad expansion.